### PR TITLE
fix(ci): add Node.js setup for release and reduce security scan triggers

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -135,6 +135,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - uses: ./.github/actions/setup-bun
 
       - name: Install dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,10 +2,7 @@ name: Security Scanning
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Daily at midnight
-  pull_request:
-  push:
-    branches: [main]
+    - cron: '0 0 * * *' # Nightly at midnight UTC
 
 jobs:
   audit:


### PR DESCRIPTION
## Summary
- Add Node.js setup to release job to ensure semantic-release has proper Node.js environment available
- Reduce security scan frequency to nightly-only to avoid redundant scans on PRs/pushes