### PR TITLE
feat(editor): add bottom scroll padding and parallax header hide effect

### DIFF
--- a/apps/desktop/renderer/src/App.css.ts
+++ b/apps/desktop/renderer/src/App.css.ts
@@ -39,6 +39,16 @@ export const mainContent = style({
   position: 'relative',
 });
 
+// Scrollable container for header + editor with parallax effect
+export const scrollContainer = style({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  overflowY: 'auto',
+  overflowX: 'hidden',
+  position: 'relative',
+});
+
 // Backlinks overlay styles
 export const backlinksOverlay = style({
   position: 'fixed',

--- a/apps/desktop/renderer/src/components/Editor/EditorRoot.css.ts
+++ b/apps/desktop/renderer/src/components/Editor/EditorRoot.css.ts
@@ -24,11 +24,13 @@ export const editorInput = style({
   flex: 1,
   outline: 'none',
   // Note: Top padding reduced since NoteHeader and mainContent provide titlebar clearance
-  padding: `${vars.spacing['4']} ${vars.spacing['8']} ${vars.spacing['12']} ${vars.spacing['8']}`,
+  // Bottom padding: 75vh allows scrolling ~3/4 up the screen from the last line
+  padding: `${vars.spacing['4']} ${vars.spacing['8']} 75vh ${vars.spacing['8']}`,
   fontSize: vars.typography.size.lg,
   lineHeight: vars.typography.lineHeight.relaxed,
   fontFamily: vars.typography.fontFamily.ui,
-  overflowY: 'auto',
+  // Scrolling is now handled by the parent scroll container for parallax header effect
+  overflowY: 'visible',
   color: vars.color.foreground,
   ':focus': {
     outline: 'none',

--- a/apps/desktop/renderer/src/components/NoteHeader/NoteHeader.css.ts
+++ b/apps/desktop/renderer/src/components/NoteHeader/NoteHeader.css.ts
@@ -9,8 +9,11 @@ import { vars } from '@scribe/design-system';
  */
 
 export const noteHeader = style({
+  // Sticky positioning for parallax scroll effect
+  position: 'sticky',
+  top: 0,
+  zIndex: 10,
   // Match editorContainer layout exactly
-  position: 'relative',
   width: '100%',
   display: 'flex',
   flexDirection: 'column',
@@ -20,9 +23,12 @@ export const noteHeader = style({
   paddingTop: vars.spacing['12'],
   paddingLeft: vars.spacing['8'],
   paddingRight: vars.spacing['8'],
-  paddingBottom: 0,
+  paddingBottom: vars.spacing['4'],
   gap: vars.spacing['2'],
   backgroundColor: vars.color.background,
+  // Smooth transform for parallax effect
+  transition: `transform ${vars.animation.duration.fast} ${vars.animation.easing.default}, opacity ${vars.animation.duration.fast} ${vars.animation.easing.default}`,
+  willChange: 'transform, opacity',
 });
 
 export const titleInput = style({

--- a/apps/desktop/renderer/src/components/NoteHeader/NoteHeader.tsx
+++ b/apps/desktop/renderer/src/components/NoteHeader/NoteHeader.tsx
@@ -9,6 +9,8 @@ interface NoteHeaderProps {
   note: Note;
   onTitleChange: (title: string) => void;
   onTagsChange: (tags: string[]) => void;
+  /** Transform Y value for parallax scroll effect */
+  translateY?: number;
 }
 
 /**
@@ -33,7 +35,7 @@ function formatDate(timestamp: number): string {
  *
  * Designed to blend seamlessly with the editor content below.
  */
-export function NoteHeader({ note, onTitleChange, onTagsChange }: NoteHeaderProps) {
+export function NoteHeader({ note, onTitleChange, onTagsChange, translateY = 0 }: NoteHeaderProps) {
   const [isAddingTag, setIsAddingTag] = useState(false);
   const [newTagValue, setNewTagValue] = useState('');
   // Local title state for immediate UI updates
@@ -128,8 +130,18 @@ export function NoteHeader({ note, onTitleChange, onTagsChange }: NoteHeaderProp
     setIsAddingTag(false);
   }, [newTagValue, note.tags, onTagsChange]);
 
+  // Calculate opacity based on translateY (fade out as it hides)
+  const opacity = translateY === 0 ? 1 : Math.max(0, 1 + translateY / 100);
+
   return (
-    <div className={styles.noteHeader}>
+    <div
+      className={styles.noteHeader}
+      style={{
+        transform: `translateY(${translateY}px)`,
+        opacity,
+        pointerEvents: opacity < 0.5 ? 'none' : 'auto',
+      }}
+    >
       {/* Editable title */}
       <input
         type="text"

--- a/apps/desktop/renderer/src/hooks/useScrollHeader.ts
+++ b/apps/desktop/renderer/src/hooks/useScrollHeader.ts
@@ -1,0 +1,98 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+interface UseScrollHeaderOptions {
+  /** Threshold in pixels before header starts hiding (default: 50) */
+  threshold?: number;
+  /** Height of the header in pixels for transform calculation */
+  headerHeight?: number;
+}
+
+interface UseScrollHeaderReturn {
+  /** Whether the header should be visible */
+  isVisible: boolean;
+  /** Current transform offset (0 to -headerHeight) for parallax effect */
+  translateY: number;
+  /** Ref to attach to the scroll container */
+  scrollContainerRef: React.RefObject<HTMLDivElement>;
+  /** Handler to call on scroll events */
+  handleScroll: () => void;
+}
+
+/**
+ * Hook for implementing a parallax hide/show header effect on scroll.
+ *
+ * - Header is always visible at the top of the document
+ * - Scrolling down hides the header with a parallax slide-up effect
+ * - Scrolling up reveals the header with a parallax slide-down effect
+ * - Uses transform for smooth 60fps animations
+ */
+export function useScrollHeader(options: UseScrollHeaderOptions = {}): UseScrollHeaderReturn {
+  const { threshold = 50, headerHeight = 100 } = options;
+
+  const [isVisible, setIsVisible] = useState(true);
+  const [translateY, setTranslateY] = useState(0);
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const lastScrollTop = useRef(0);
+  const accumulatedDelta = useRef(0);
+  const rafId = useRef<number | null>(null);
+
+  const handleScroll = useCallback(() => {
+    // Cancel any pending RAF to avoid stacking
+    if (rafId.current) {
+      cancelAnimationFrame(rafId.current);
+    }
+
+    rafId.current = requestAnimationFrame(() => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      const scrollTop = container.scrollTop;
+      const delta = scrollTop - lastScrollTop.current;
+
+      // At the top of the document, always show header
+      if (scrollTop <= threshold) {
+        setIsVisible(true);
+        setTranslateY(0);
+        accumulatedDelta.current = 0;
+        lastScrollTop.current = scrollTop;
+        return;
+      }
+
+      // Accumulate scroll delta for parallax effect
+      if (delta > 0) {
+        // Scrolling down - hide header
+        accumulatedDelta.current = Math.min(accumulatedDelta.current + delta, headerHeight);
+      } else if (delta < 0) {
+        // Scrolling up - show header
+        accumulatedDelta.current = Math.max(accumulatedDelta.current + delta, 0);
+      }
+
+      // Calculate parallax transform
+      const newTranslateY = -accumulatedDelta.current;
+      setTranslateY(newTranslateY);
+
+      // Update visibility based on accumulated delta
+      const shouldBeVisible = accumulatedDelta.current < headerHeight * 0.5;
+      setIsVisible(shouldBeVisible);
+
+      lastScrollTop.current = scrollTop;
+    });
+  }, [threshold, headerHeight]);
+
+  // Cleanup RAF on unmount
+  useEffect(() => {
+    return () => {
+      if (rafId.current) {
+        cancelAnimationFrame(rafId.current);
+      }
+    };
+  }, []);
+
+  return {
+    isVisible,
+    translateY,
+    scrollContainerRef,
+    handleScroll,
+  };
+}


### PR DESCRIPTION
## Summary
- Add 75vh bottom padding to the editor so users can scroll the last line ~3/4 up the screen, preventing text from being cut off by the floating bar
- Implement a sticky note header with parallax hide/show effect - the header fades out and slides up when scrolling down, and smoothly reappears when scrolling up (always visible at document top)